### PR TITLE
Allow pulling from private OCI registries using environment variables

### DIFF
--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -171,7 +171,23 @@ func TartExec(
 	ctx context.Context,
 	args ...string,
 ) (string, string, error) {
+	return TartExecWithEnv(ctx, nil, args...)
+}
+
+func TartExecWithEnv(
+	ctx context.Context,
+	env map[string]string,
+	args ...string,
+) (string, string, error) {
 	cmd := exec.CommandContext(ctx, tartCommandName, args...)
+
+	// Base environment
+	cmd.Env = cmd.Environ()
+
+	// Environment overrides
+	for key, value := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
 
 	var stdout, stderr bytes.Buffer
 


### PR DESCRIPTION
I don't think we need to store any sensitive state on the host for such a simple operation as `pull`, so I've skipped the `tart login` part.

The executor will now correctly pass `TART_REGISTRY_{USERNAME,PASSWORD}` environment variables to the `tart pull` or, if provided, fallback to using the GitLab-provided credentials.

Resolves https://github.com/cirruslabs/gitlab-tart-executor/issues/7, resolves https://github.com/cirruslabs/gitlab-tart-executor/issues/6.