### PR TITLE
config stage: support --builds-dir command-line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ that required paid sponsorship upon exceeding a free limit.
 
 ### `config` stage
 
-| Argument      | Default | Description                                             |
-|---------------|---------|---------------------------------------------------------|
-| `--cache-dir` |         | Path to a directory on host to use for caching purposes |
+| Argument       | Default | Description                                             |
+|----------------|---------|---------------------------------------------------------|
+| `--builds-dir` |         | Path to a directory on host to use for storing builds   |
+| `--cache-dir`  |         | Path to a directory on host to use for caching purposes |
 
 ### `prepare` stage
 

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -71,11 +71,13 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		}
 	} else if buildsDir != "" {
 		gitlabRunnerConfig.BuildsDir = "/Volumes/My Shared Files/buildsdir"
+		buildsDir = os.ExpandEnv(buildsDir)
 		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalBuildsDir] = buildsDir
 	}
 
 	if cacheDir != "" {
 		gitlabRunnerConfig.CacheDir = "/Volumes/My Shared Files/cachedir"
+		cacheDir = os.ExpandEnv(cacheDir)
 		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalCacheDir] = cacheDir
 	}
 

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -73,12 +73,20 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		gitlabRunnerConfig.BuildsDir = "/Volumes/My Shared Files/buildsdir"
 		buildsDir = os.ExpandEnv(buildsDir)
 		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalBuildsDir] = buildsDir
+
+		if err := os.MkdirAll(buildsDir, 0700); err != nil {
+			return err
+		}
 	}
 
 	if cacheDir != "" {
 		gitlabRunnerConfig.CacheDir = "/Volumes/My Shared Files/cachedir"
 		cacheDir = os.ExpandEnv(cacheDir)
 		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalCacheDir] = cacheDir
+
+		if err := os.MkdirAll(cacheDir, 0700); err != nil {
+			return err
+		}
 	}
 
 	jsonBytes, err := json.MarshalIndent(&gitlabRunnerConfig, "", "  ")

--- a/internal/tart/config.go
+++ b/internal/tart/config.go
@@ -19,6 +19,11 @@ const (
 	// and remove repetition from the Config's struct declaration.
 	envPrefixTartExecutor = "TART_EXECUTOR_"
 
+	// EnvTartExecutorInternalBuildsDir is an internal environment variable
+	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
+	// by the user.
+	EnvTartExecutorInternalBuildsDir = "TART_EXECUTOR_INTERNAL_BUILDS_DIR"
+
 	// EnvTartExecutorInternalCacheDir is an internal environment variable
 	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
 	// by the user.

--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -90,12 +90,14 @@ func (vm *VM) Start(config Config, gitLabEnv *gitlab.Env, customDirectoryMounts 
 		runArgs = append(runArgs, "--no-graphics")
 	}
 
-	if config.HostDir {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("hostdir:%s", gitLabEnv.HostDirPath()))
-	}
-
 	for _, customDirectoryMount := range customDirectoryMounts {
 		runArgs = append(runArgs, "--dir", customDirectoryMount)
+	}
+
+	if config.HostDir {
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("hostdir:%s", gitLabEnv.HostDirPath()))
+	} else if buildsDir, ok := os.LookupEnv(EnvTartExecutorInternalBuildsDir); ok {
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("buildsdir:%s", buildsDir))
 	}
 
 	if cacheDir, ok := os.LookupEnv(EnvTartExecutorInternalCacheDir); ok {


### PR DESCRIPTION
https://github.com/cirruslabs/gitlab-tart-executor/commit/c3f8a9ea71e45928042104981a17282d8dc73200 resolves https://github.com/cirruslabs/gitlab-tart-executor/issues/26.

https://github.com/cirruslabs/gitlab-tart-executor/commit/fc191cf3096bc8af5a98d26a0c705cd6d277dbe2 resolves https://github.com/cirruslabs/gitlab-tart-executor/issues/21.