### PR TITLE
Use TART_REGISTRY_HOSTNAME when GitLab provides us registry credenrtials

### DIFF
--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -153,6 +153,7 @@ func additionalPullEnv(registry *gitlab.Registry) map[string]string {
 	// Otherwise fallback to GitLab's provided registry credentials, if any
 	if registry != nil {
 		return map[string]string{
+			"TART_REGISTRY_HOSTNAME": registry.Address,
 			"TART_REGISTRY_USERNAME": registry.User,
 			"TART_REGISTRY_PASSWORD": registry.Password,
 		}

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -144,10 +144,17 @@ func additionalPullEnv(registry *gitlab.Registry) map[string]string {
 	tartRegistryUsername, tartRegistryUsernameOK := os.LookupEnv("CUSTOM_ENV_TART_REGISTRY_USERNAME")
 	tartRegistryPassword, tartRegistryPasswordOK := os.LookupEnv("CUSTOM_ENV_TART_REGISTRY_PASSWORD")
 	if tartRegistryUsernameOK && tartRegistryPasswordOK {
-		return map[string]string{
+		result := map[string]string{
 			"TART_REGISTRY_USERNAME": tartRegistryUsername,
 			"TART_REGISTRY_PASSWORD": tartRegistryPassword,
 		}
+
+		tartRegistryHostname, tartRegistryHostnameOK := os.LookupEnv("CUSTOM_ENV_TART_REGISTRY_HOSTNAME")
+		if tartRegistryHostnameOK {
+			result["TART_REGISTRY_HOSTNAME"] = tartRegistryHostname
+		}
+
+		return result
 	}
 
 	// Otherwise fallback to GitLab's provided registry credentials, if any


### PR DESCRIPTION
Requires https://github.com/cirruslabs/tart/pull/545.

Resolves https://github.com/cirruslabs/gitlab-tart-executor/issues/28.