### PR TITLE
Do not hide the "tart run" output

### DIFF
--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -108,6 +108,9 @@ func (vm *VM) Start(config Config, gitLabEnv *gitlab.Env, customDirectoryMounts 
 
 	cmd := exec.Command(nohupCommandName, runArgs...)
 
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
 	err := cmd.Start()
 	if err != nil {
 		return err


### PR DESCRIPTION
Should help with diagnosing `tart run` errors, like in https://github.com/cirruslabs/gitlab-tart-executor/issues/30.