### PR TITLE
Avoid using nohup + monitor "tart run" output using files

### DIFF
--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -83,6 +83,10 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Monitor "tart run" command's output to detect errors
+	go vm.MonitorOutput()
+
 	log.Println("Waiting for the VM to boot and be SSH-able...")
 	ssh, err := vm.OpenSSH(cmd.Context(), config)
 	if err != nil {

--- a/internal/commands/run/run.go
+++ b/internal/commands/run/run.go
@@ -31,6 +31,9 @@ func runScriptInsideVM(cmd *cobra.Command, args []string) error {
 
 	vm := tart.ExistingVM(*gitLabEnv)
 
+	// Monitor "tart run" command's output to detect errors
+	go vm.MonitorOutput()
+
 	config, err := tart.NewConfigFromEnvironment()
 	if err != nil {
 		return err

--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -108,9 +108,6 @@ func (vm *VM) Start(config Config, gitLabEnv *gitlab.Env, customDirectoryMounts 
 
 	cmd := exec.Command(tartCommandName, runArgs...)
 
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid: true,
 	}


### PR DESCRIPTION
* https://github.com/cirruslabs/gitlab-tart-executor/commit/2e67fae907b4dc75b4c2ddc338db5f7d4f369aff — to fix the `nohup` error in https://github.com/cirruslabs/gitlab-tart-executor/issues/30#issuecomment-1636068414
* https://github.com/cirruslabs/gitlab-tart-executor/commit/7334ada5702a0d6b841e44b5b7518f2449a65190 + https://github.com/cirruslabs/gitlab-tart-executor/commit/659248c918ac74116d1915b0b22934b4053f4dca — to avoid the issue when GitLab Runner waits for the already succeeded "prepare" step indefinitely because `tart run` process is holding GitLab Runner's file descriptors [that we passed to `tart run`](https://github.com/cirruslabs/gitlab-tart-executor/pull/32) in hostage (see https://github.com/golang/go/issues/23019)