### PR TITLE
Improve builds/cache dir documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ that required paid sponsorship upon exceeding a free limit.
 
 | Argument       | Default | Description                                             |
 |----------------|---------|---------------------------------------------------------|
-| `--builds-dir` |         | Path to a directory on host to use for storing builds   |
-| `--cache-dir`  |         | Path to a directory on host to use for caching purposes |
+| `--builds-dir` |         | Path to a directory on host to use for storing builds. Don't forget to mount `buildsdir` using `--dir buildsdir:/path/on/host/builds` in [prepare](#prepare-stage) stage.   |
+| `--cache-dir`  |         | Path to a directory on host to use for caching purposes. Don't forget to mount `cachedir` using `--dir cachedir:/path/on/host/cache` in [prepare](#prepare-stage) stage. |
 
 ### `prepare` stage
 


### PR DESCRIPTION
👋 I have been implementing primarily local Gitlab CI caching, but when I was at it I also mounted builds dir from host. 

Everything went pretty well until I ran to error:
```
fatal: unable to access 'https://<gitlabURL>/<repo>/': error setting certificate verify locations:  CAfile: /Volumes/My Shared Files/buildsdir/<repo>.tmp/CI_SERVER_TLS_CA_FILE CApath: none
```

I then played with config stage and found out that I actually need to mount _buildsdir/cachedir_ using `--dir` argument for prepare stage, but I think that for others it would be useful to have it in the docs.