### PR TITLE
prepare stage: introduce --no-auto-prune command-line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,13 @@ that required paid sponsorship upon exceeding a free limit.
 
 ### `prepare` stage
 
-| Argument          | Default     | Description                                                                                                          |
-|-------------------|-------------|----------------------------------------------------------------------------------------------------------------------|
-| `--concurrency`   | 1           | Maximum number of concurrently running Tart VMs to calculate the `auto` resources                                    |
-| `--cpu`           | no override | Override default image CPU configuration (number of CPUs or `auto`<sup>1</sup>)                                      |
-| `--memory`        | no override | Override default image memory configuration (size in megabytes or `auto`<sup>1</sup>)                                |
-| `--dir`           |             | `--dir` arguments to pass to `tart run`, can be specified multiple times                                             |
-| `--no-auto-prune` | false       | set `TART_NO_AUTO_PRUNE=true` environment variable for Tart invocations to disable the Tart's auto-pruning mechanism |
+| Argument         | Default     | Description                                                                                                                                                     |
+|------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--concurrency`  | 1           | Maximum number of concurrently running Tart VMs to calculate the `auto` resources                                                                               |
+| `--cpu`          | no override | Override default image CPU configuration (number of CPUs or `auto`<sup>1</sup>)                                                                                 |
+| `--memory`       | no override | Override default image memory configuration (size in megabytes or `auto`<sup>1</sup>)                                                                           |
+| `--dir`          |             | `--dir` arguments to pass to `tart run`, can be specified multiple times                                                                                        |
+| `--auto-prune`   | true        | Whether to enable or disable the Tart's auto-pruning mechanism (sets the `TART_NO_AUTO_PRUNE` environment variable for Tart command invocations under the hood) |
 
 <sup>1</sup>: automatically distributes all host resources according to the concurrency level (for example, VM gets all of the host CPU and RAM assigned when `--concurrency` is 1, and half of that when `--concurrency` is 2)
 

--- a/README.md
+++ b/README.md
@@ -150,12 +150,13 @@ that required paid sponsorship upon exceeding a free limit.
 
 ### `prepare` stage
 
-| Argument        | Default     | Description                                                                          |
-|-----------------|-------------|--------------------------------------------------------------------------------------|
-| `--concurrency` | 1           | Maximum number of concurrently running Tart VMs to calculate the `auto` resources    |
-| `--cpu`         | no override | Override default image CPU configuration (number of CPUs or `auto`<sup>1</sup>)      |
-| `--memory`      | no override | Override default image memory configuration (size in megabytes or `auto`<sup>1</sup>) |
-| `--dir`         |             | `--dir` arguments to pass to `tart run`, can be specified multiple times             |
+| Argument          | Default     | Description                                                                                                          |
+|-------------------|-------------|----------------------------------------------------------------------------------------------------------------------|
+| `--concurrency`   | 1           | Maximum number of concurrently running Tart VMs to calculate the `auto` resources                                    |
+| `--cpu`           | no override | Override default image CPU configuration (number of CPUs or `auto`<sup>1</sup>)                                      |
+| `--memory`        | no override | Override default image memory configuration (size in megabytes or `auto`<sup>1</sup>)                                |
+| `--dir`           |             | `--dir` arguments to pass to `tart run`, can be specified multiple times                                             |
+| `--no-auto-prune` | false       | set `TART_NO_AUTO_PRUNE=true` environment variable for Tart invocations to disable the Tart's auto-pruning mechanism |
 
 <sup>1</sup>: automatically distributes all host resources according to the concurrency level (for example, VM gets all of the host CPU and RAM assigned when `--concurrency` is 1, and half of that when `--concurrency` is 2)
 

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -24,6 +24,7 @@ var concurrency uint64
 var cpuOverrideRaw string
 var memoryOverrideRaw string
 var customDirectoryMounts []string
+var noAutoPrune bool
 
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
@@ -40,6 +41,9 @@ func NewCommand() *cobra.Command {
 		"Override default image memory configuration (size in megabytes or \"auto\")")
 	command.PersistentFlags().StringArrayVar(&customDirectoryMounts, "dir", []string{},
 		"\"--dir\" arguments to pass to \"tart run\", can be specified multiple times")
+	command.PersistentFlags().BoolVar(&noAutoPrune, "no-auto-prune", false,
+		"set \"TART_NO_AUTO_PRUNE=true\" environment variable for Tart invocations"+
+			"to disable the Tart's auto-pruning mechanism")
 
 	return command
 }
@@ -53,6 +57,12 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 	memoryOverride, err := parseMemoryOverride(cmd.Context(), memoryOverrideRaw)
 	if err != nil {
 		return err
+	}
+
+	if noAutoPrune {
+		if err := os.Setenv("TART_NO_AUTO_PRUNE", "true"); err != nil {
+			return err
+		}
 	}
 
 	gitLabEnv, err := gitlab.InitEnv()

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -24,7 +24,7 @@ var concurrency uint64
 var cpuOverrideRaw string
 var memoryOverrideRaw string
 var customDirectoryMounts []string
-var noAutoPrune bool
+var autoPrune bool
 
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
@@ -41,9 +41,9 @@ func NewCommand() *cobra.Command {
 		"Override default image memory configuration (size in megabytes or \"auto\")")
 	command.PersistentFlags().StringArrayVar(&customDirectoryMounts, "dir", []string{},
 		"\"--dir\" arguments to pass to \"tart run\", can be specified multiple times")
-	command.PersistentFlags().BoolVar(&noAutoPrune, "no-auto-prune", false,
-		"set \"TART_NO_AUTO_PRUNE=true\" environment variable for Tart invocations"+
-			"to disable the Tart's auto-pruning mechanism")
+	command.PersistentFlags().BoolVar(&autoPrune, "auto-prune", true,
+		"Whether to enable or disable the Tart's auto-pruning mechanism (sets the "+
+			"TART_NO_AUTO_PRUNE environment variable for Tart command invocations under the hood)")
 
 	return command
 }
@@ -59,7 +59,9 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if noAutoPrune {
+	// Auto-prune is enabled by default in Tart,
+	// so we only need to act when it's set to "false"
+	if !autoPrune {
 		if err := os.Setenv("TART_NO_AUTO_PRUNE", "true"); err != nil {
 			return err
 		}


### PR DESCRIPTION
GitLab Runner prefixes all external environment variables passed to the custom runner with `CUSTOM_ENV_*`, so 
 https://github.com/cirruslabs/gitlab-tart-executor/issues/41#issuecomment-1791145843 wouldn't work.

Since `TART_NO_AUTO_PRUNE` might influence behavior for other tasks, it makes sense to add it as a command-line flag, instead of an [environment variable](https://github.com/cirruslabs/gitlab-tart-executor?tab=readme-ov-file#supported-environment-variables).