### PR TITLE
Propagate TART_EXECUTOR_INSECURE_PULL to "tart clone" invocation

### DIFF
--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -68,6 +68,10 @@ func (vm *VM) cloneAndConfigure(
 ) error {
 	cloneArgs := []string{"clone", gitLabEnv.JobImage, vm.id}
 
+	if config.InsecurePull {
+		cloneArgs = append(cloneArgs, "--insecure")
+	}
+
 	if config.PullConcurrency != 0 {
 		cloneArgs = append(cloneArgs, "--concurrency",
 			strconv.FormatUint(uint64(config.PullConcurrency), 10))


### PR DESCRIPTION
Resolves https://github.com/cirruslabs/gitlab-tart-executor/issues/59.