### PR TITLE
Mount directories directly into `$HOME`

### DIFF
--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -95,13 +95,13 @@ func runConfig(cmd *cobra.Command, args []string) error {
 	// Figure out the builds directory override to use
 	switch {
 	case tartConfig.HostDir:
-		gitlabRunnerConfig.BuildsDir = "/Volumes/My Shared Files/hostdir"
+		gitlabRunnerConfig.BuildsDir = fmt.Sprintf("/Users/%s/hostdir", tartConfig.SSHUsername)
 
 		if err := os.MkdirAll(gitLabEnv.HostDirPath(), 0700); err != nil {
 			return err
 		}
 	case buildsDir != "":
-		gitlabRunnerConfig.BuildsDir = "/Volumes/My Shared Files/buildsdir"
+		gitlabRunnerConfig.BuildsDir = fmt.Sprintf("/Users/%s/buildsdir", tartConfig.SSHUsername)
 		buildsDir = os.ExpandEnv(buildsDir)
 		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalBuildsDir] = buildsDir
 
@@ -115,7 +115,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 	// Figure out the cache directory override to use
 	switch {
 	case cacheDir != "":
-		gitlabRunnerConfig.CacheDir = "/Volumes/My Shared Files/cachedir"
+		gitlabRunnerConfig.CacheDir = fmt.Sprintf("/Users/%s/cachedir", tartConfig.SSHUsername)
 		cacheDir = os.ExpandEnv(cacheDir)
 		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalCacheDir] = cacheDir
 

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -201,11 +201,15 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 		}
 		defer session.Close()
 
+		mkdirScript := fmt.Sprintf(
+			"mkdir -p /Users/%s/%s",
+			config.SSHUsername, dirToMount,
+		)
 		mountScript := fmt.Sprintf(
-			"mount_virtiofs tart.virtiofs.%s /Users/%s/%s\n",
+			"mount_virtiofs tart.virtiofs.%s /Users/%s/%s",
 			dirToMount, config.SSHUsername, dirToMount,
 		)
-		session.Stdin = bytes.NewBufferString(mountScript)
+		session.Stdin = bytes.NewBufferString(strings.Join([]string{mkdirScript, mountScript, ""}, "\n")
 		session.Stdout = os.Stdout
 		session.Stderr = os.Stderr
 

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -201,15 +201,10 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 		}
 		defer session.Close()
 
-		mkdirScript := fmt.Sprintf(
-			"mkdir -p /Users/%s/%s",
-			config.SSHUsername, dirToMount,
-		)
-		mountScript := fmt.Sprintf(
-			"mount_virtiofs tart.virtiofs.%s /Users/%s/%s",
-			dirToMount, config.SSHUsername, dirToMount,
-		)
-		session.Stdin = bytes.NewBufferString(strings.Join([]string{mkdirScript, mountScript, ""}, "\n")
+		mountPoint := fmt.Sprintf("/Users/%s/%s", config.SSHUsername, dirToMount)
+		mkdirScript := fmt.Sprintf("mkdir -p %s", mountPoint)
+		mountScript := fmt.Sprintf("mount_virtiofs tart.virtiofs.%s %s", dirToMount, mountPoint)
+		session.Stdin = bytes.NewBufferString(strings.Join([]string{mkdirScript, mountScript, ""}, "\n"))
 		session.Stdout = os.Stdout
 		session.Stderr = os.Stderr
 

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -181,6 +181,39 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 		log.Printf("Timezone was set to %s!\n", tz)
 	}
 
+	dirsToMount := []string{}
+	if config.HostDir {
+		dirsToMount = append(dirsToMount, "hostdir")
+	}
+	if _, ok := os.LookupEnv(tart.EnvTartExecutorInternalBuildsDir); ok {
+		dirsToMount = append(dirsToMount, "buildsdir")
+	}
+	if _, ok := os.LookupEnv(tart.EnvTartExecutorInternalCacheDir); ok {
+		dirsToMount = append(dirsToMount, "cachedir")
+	}
+
+	for _, dirToMount := range dirsToMount {
+		log.Printf("Mounting %s...\n", dirToMount)
+
+		session, err := ssh.NewSession()
+		if err != nil {
+			return err
+		}
+		defer session.Close()
+
+		session.Stdin = bytes.NewBufferString(fmt.Sprintf("mount_virtiofs tart.virtiofs.%s /Users/%s/%s\n", dirToMount, config.SSHUsername, dirToMount))
+		session.Stdout = os.Stdout
+		session.Stderr = os.Stderr
+
+		if err := session.Shell(); err != nil {
+			return err
+		}
+
+		if err := session.Wait(); err != nil {
+			return err
+		}
+	}
+
 	log.Println("VM is ready.")
 
 	return ssh.Close()

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -201,7 +201,11 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 		}
 		defer session.Close()
 
-		session.Stdin = bytes.NewBufferString(fmt.Sprintf("mount_virtiofs tart.virtiofs.%s /Users/%s/%s\n", dirToMount, config.SSHUsername, dirToMount))
+		mountScript := fmt.Sprintf(
+			"mount_virtiofs tart.virtiofs.%s /Users/%s/%s\n",
+			dirToMount, config.SSHUsername, dirToMount,
+		)
+		session.Stdin = bytes.NewBufferString(mountScript)
 		session.Stdout = os.Stdout
 		session.Stderr = os.Stderr
 

--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -124,13 +124,13 @@ func (vm *VM) Start(
 	}
 
 	if config.HostDir {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("hostdir:%s", gitLabEnv.HostDirPath()))
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.hostdir", gitLabEnv.HostDirPath()))
 	} else if buildsDir, ok := os.LookupEnv(EnvTartExecutorInternalBuildsDir); ok {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("buildsdir:%s", buildsDir))
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.buildsdir", buildsDir))
 	}
 
 	if cacheDir, ok := os.LookupEnv(EnvTartExecutorInternalCacheDir); ok {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("cachedir:%s", cacheDir))
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.cachedir", cacheDir))
 	}
 
 	runArgs = append(runArgs, vm.id)


### PR DESCRIPTION
After introducing of https://github.com/cirruslabs/tart/pull/733 we can use different VirtioFS tags for different directories and precisely mount them into exact locations.

`/Volumes/My Shared Files/` default path is error-prone since some tools don't like whitespaces in paths. With this change directories will be directly mounted into `$HOME`.

Fixes #64