### PR TITLE
Unique VirtioFS Tags

### DIFF
--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -203,7 +203,7 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 
 		mountPoint := fmt.Sprintf("/Users/%s/%s", config.SSHUsername, dirToMount)
 		mkdirScript := fmt.Sprintf("mkdir -p %s", mountPoint)
-		mountScript := fmt.Sprintf("mount_virtiofs tart.virtiofs.%s %s", dirToMount, mountPoint)
+		mountScript := fmt.Sprintf("mount_virtiofs tart.virtiofs.%s.%s %s", dirToMount, gitLabEnv.JobID, mountPoint)
 		session.Stdin = bytes.NewBufferString(strings.Join([]string{mkdirScript, mountScript, ""}, "\n"))
 		session.Stdout = os.Stdout
 		session.Stderr = os.Stderr

--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -128,13 +128,13 @@ func (vm *VM) Start(
 	}
 
 	if config.HostDir {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.hostdir", gitLabEnv.HostDirPath()))
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.hostdir.%s", gitLabEnv.HostDirPath(), gitLabEnv.JobID))
 	} else if buildsDir, ok := os.LookupEnv(EnvTartExecutorInternalBuildsDir); ok {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.buildsdir", buildsDir))
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.buildsdir.%s", buildsDir, gitLabEnv.JobID))
 	}
 
 	if cacheDir, ok := os.LookupEnv(EnvTartExecutorInternalCacheDir); ok {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.cachedir", cacheDir))
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.cachedir.%s", cacheDir, gitLabEnv.JobID))
 	}
 
 	runArgs = append(runArgs, vm.id)


### PR DESCRIPTION
As reported in [this comment](https://github.com/cirruslabs/gitlab-tart-executor/issues/73#issuecomment-2075099907) it seems host VirtioFS server is getting confused when the same tag is used in two VMs simultaneously. Let's make them unique.