### PR TITLE
Support Linux

### DIFF
--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -53,7 +53,10 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		// to be absolute[1].
 		//
 		// 2. GitLab Runner uses relative paths internally which results in improper directory traversal[2],
-		// this is why we use "/private/tmp" instead of just "/tmp" here as a workaround.
+		// so instead of "/tmp" we need to use "/private/tmp" here as a workaround.
+		//
+		// 3. However, there's no "/private/tmp" on Linux. So we use the lowest common denominator
+		// in the form of "/var/tmp". It's both (1) not a symbolic link and (2) is present on both platforms.
 		//
 		// [1]: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runners-section
 		// [2]: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/31003

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -57,8 +57,8 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		//
 		// [1]: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runners-section
 		// [2]: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/31003
-		BuildsDir: "/private/tmp/builds",
-		CacheDir:  "/private/tmp/cache",
+		BuildsDir: "/var/tmp/builds",
+		CacheDir:  "/var/tmp/cache",
 		JobEnv:    map[string]string{},
 	}
 
@@ -95,15 +95,14 @@ func runConfig(cmd *cobra.Command, args []string) error {
 	// Figure out the builds directory override to use
 	switch {
 	case tartConfig.HostDir:
-		gitlabRunnerConfig.BuildsDir = fmt.Sprintf("/Users/%s/hostdir", tartConfig.SSHUsername)
+		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalBuildsDirOnHost] = gitLabEnv.HostDirPath()
 
 		if err := os.MkdirAll(gitLabEnv.HostDirPath(), 0700); err != nil {
 			return err
 		}
 	case buildsDir != "":
-		gitlabRunnerConfig.BuildsDir = fmt.Sprintf("/Users/%s/buildsdir", tartConfig.SSHUsername)
 		buildsDir = os.ExpandEnv(buildsDir)
-		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalBuildsDir] = buildsDir
+		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalBuildsDirOnHost] = buildsDir
 
 		if err := os.MkdirAll(buildsDir, 0700); err != nil {
 			return err
@@ -115,9 +114,8 @@ func runConfig(cmd *cobra.Command, args []string) error {
 	// Figure out the cache directory override to use
 	switch {
 	case cacheDir != "":
-		gitlabRunnerConfig.CacheDir = fmt.Sprintf("/Users/%s/cachedir", tartConfig.SSHUsername)
 		cacheDir = os.ExpandEnv(cacheDir)
-		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalCacheDir] = cacheDir
+		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalCacheDirOnHost] = cacheDir
 
 		if err := os.MkdirAll(cacheDir, 0700); err != nil {
 			return err
@@ -125,6 +123,11 @@ func runConfig(cmd *cobra.Command, args []string) error {
 	case guestCacheDir != "":
 		gitlabRunnerConfig.CacheDir = guestCacheDir
 	}
+
+	// Propagate builds and cache directory locations in the guest
+	// because GitLab Runner won't do this for us
+	gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalBuildsDir] = gitlabRunnerConfig.BuildsDir
+	gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalCacheDir] = gitlabRunnerConfig.CacheDir
 
 	jsonBytes, err := json.MarshalIndent(&gitlabRunnerConfig, "", "  ")
 	if err != nil {

--- a/internal/commands/prepare/install-gitlab-runner-auto.sh
+++ b/internal/commands/prepare/install-gitlab-runner-auto.sh
@@ -10,7 +10,18 @@
 #
 set -euo pipefail
 
-GITLAB_RUNNER_URL="https://gitlab-runner-downloads.s3.amazonaws.com/latest/binaries/gitlab-runner-darwin-arm64"
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case $ARCH in
+  aarch64)
+      ARCH="arm64"
+      ;;
+  x86_64)
+      ARCH="amd64"
+      ;;
+esac
+
+GITLAB_RUNNER_URL="https://gitlab-runner-downloads.s3.amazonaws.com/latest/binaries/gitlab-runner-${OS}-${ARCH}"
 GITLAB_RUNNER_PATH="/usr/local/bin/gitlab-runner"
 
 # Is GitLab Runner already installed?

--- a/internal/commands/prepare/install-gitlab-runner-curl.sh
+++ b/internal/commands/prepare/install-gitlab-runner-curl.sh
@@ -10,8 +10,19 @@
 #
 set -euo pipefail
 
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case $ARCH in
+  aarch64)
+      ARCH="arm64"
+      ;;
+  x86_64)
+      ARCH="amd64"
+      ;;
+esac
+
 GITLAB_RUNNER_VERSION="latest"
-GITLAB_RUNNER_URL="https://gitlab-runner-downloads.s3.amazonaws.com/${GITLAB_RUNNER_VERSION}/binaries/gitlab-runner-darwin-arm64"
+GITLAB_RUNNER_URL="https://gitlab-runner-downloads.s3.amazonaws.com/${GITLAB_RUNNER_VERSION}/binaries/gitlab-runner-${OS}-${ARCH}"
 GITLAB_RUNNER_PATH="/usr/local/bin/gitlab-runner"
 
 # Is GitLab Runner already installed?

--- a/internal/tart/config.go
+++ b/internal/tart/config.go
@@ -24,10 +24,20 @@ const (
 	// by the user.
 	EnvTartExecutorInternalBuildsDir = "TART_EXECUTOR_INTERNAL_BUILDS_DIR"
 
+	// EnvTartExecutorInternalBuildsDirOnHost is an internal environment variable
+	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
+	// by the user.
+	EnvTartExecutorInternalBuildsDirOnHost = "TART_EXECUTOR_INTERNAL_BUILDS_DIR_ON_HOST"
+
 	// EnvTartExecutorInternalCacheDir is an internal environment variable
 	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
 	// by the user.
 	EnvTartExecutorInternalCacheDir = "TART_EXECUTOR_INTERNAL_CACHE_DIR"
+
+	// EnvTartExecutorInternalCacheDirOnHost is an internal environment variable
+	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
+	// by the user.
+	EnvTartExecutorInternalCacheDirOnHost = "TART_EXECUTOR_INTERNAL_CACHE_DIR_ON_HOST"
 )
 
 type Config struct {

--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -3,6 +3,7 @@ package tart
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,6 +34,10 @@ var (
 
 type VM struct {
 	id string
+}
+
+type VMInfo struct {
+	OS string `json:"os"`
 }
 
 func ExistingVM(gitLabEnv gitlab.Env) *VM {
@@ -276,6 +281,21 @@ func (vm *VM) IP(ctx context.Context, config Config) (string, error) {
 	}
 
 	return strings.TrimSpace(stdout), nil
+}
+
+func (vm *VM) Info(ctx context.Context) (*VMInfo, error) {
+	stdout, _, err := TartExec(ctx, "get", "--format", "json", vm.id)
+	if err != nil {
+		return nil, err
+	}
+
+	var vmInfo VMInfo
+
+	if err := json.Unmarshal([]byte(stdout), &vmInfo); err != nil {
+		return nil, err
+	}
+
+	return &vmInfo, nil
 }
 
 func (vm *VM) Stop() error {

--- a/internal/tart/vm.go
+++ b/internal/tart/vm.go
@@ -148,15 +148,14 @@ func (vm *VM) Start(
 		runArgs = append(runArgs, "--disk", customDiskMount)
 	}
 
-	if config.HostDir {
-		hostDir := gitLabEnv.HostDirPath()
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.hostdir.%s", hostDir, gitLabEnv.JobID))
-	} else if buildsDir, ok := os.LookupEnv(EnvTartExecutorInternalBuildsDir); ok {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.buildsdir.%s", buildsDir, gitLabEnv.JobID))
+	if buildsDir, ok := os.LookupEnv(EnvTartExecutorInternalBuildsDirOnHost); ok {
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.buildsdir.%s",
+			buildsDir, gitLabEnv.JobID))
 	}
 
-	if cacheDir, ok := os.LookupEnv(EnvTartExecutorInternalCacheDir); ok {
-		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.cachedir.%s", cacheDir, gitLabEnv.JobID))
+	if cacheDir, ok := os.LookupEnv(EnvTartExecutorInternalCacheDirOnHost); ok {
+		runArgs = append(runArgs, "--dir", fmt.Sprintf("%s:tag=tart.virtiofs.cachedir.%s",
+			cacheDir, gitLabEnv.JobID))
 	}
 
 	runArgs = append(runArgs, vm.id)


### PR DESCRIPTION
By:

1. dynamically detecting OS and architecture in `install-gitlab-runner*.sh` scripts
1. handling the builds and cache directories in a cross-platform fashion
1. using a different `mount` invocation on Linux, as suggested in https://github.com/cirruslabs/gitlab-tart-executor/issues/95#issuecomment-2512278598

Resolves https://github.com/cirruslabs/gitlab-tart-executor/issues/95.