### PR TITLE
Defer ssh.Close() to always close SSH connection in prepare

### DIFF
--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -140,6 +140,7 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer ssh.Close()
 
 	log.Println("Was able to SSH!")
 
@@ -251,7 +252,7 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 
 	log.Println("VM is ready.")
 
-	return ssh.Close()
+	return nil
 }
 
 func ensureImageIsAllowed(image string) error {


### PR DESCRIPTION
Looks like previously there was no error path so the `return ssh.Close()` made sense. Now there are several. If the error of `ssh.Close` is important to return, then you could use a named return value.