### PR TITLE
Introduce --default-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,20 @@
 Custom [GitLab Runner](https://docs.gitlab.com/runner/) executor to run jobs inside ephemeral [Tart](https://tart.run/) macOS virtual machines.
 
 > [!IMPORTANT]
-> 
+>
 > **macOS 15 (Sequoia)**
-> 
+>
 > In case you've upgraded and encountering an issue below:
-> 
+>
 > ```
 > Waiting for the VM to boot and be SSH-able...
 > ```
-> 
+>
 > This is likely related to the [newly introduced "Local Network" permission](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy) on macOS Sequoia and the fact that GitLab Runner's binary might have no `LC_UUID` identifier, which is critical for the local network privacy mechanism.
-> 
+>
 > Make sure you have installed the latest GitLab Runner (`>=17.6.0`) [from Homebrew](https://formulae.brew.sh/formula/gitlab-runner).
-> 
+>
 > Homebrew version [includes a fix for lacking `LC_UUID`](https://github.com/Homebrew/homebrew-core/commit/77fcd447733f6f063ef4f635202d3748fdfb8e26) and it should ask you for a "Local Network" permission correctly when GitLab Tart Executor tries to establish connection with the Tart VMs.
-> 
 
 ## Configuration
 
@@ -161,7 +160,7 @@ that required paid sponsorship upon exceeding a free limit.
 ### `config` stage
 
 | Argument                         | Default | Description                                                                                                                                                                                           |
-|----------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--builds-dir`                   |         | Path to a directory on host to use for storing builds, automatically mounts that directory to the guest VM (mutually exclusive with `--guest-builds-dir`)                                             |
 | `--cache-dir`                    |         | Path to a directory on host to use for caching purposes, automatically mounts that directory to the guest VM (mutually exclusive with `--guest-cache-dir`)                                            |
 | `--guest-builds-dir`<sup>1</sup> |         | Path to a directory in guest to use for storing builds, useful when mounting a block device (via [`--disk` command-line argument](#prepare-stage)) to the VM (mutually exclusive with `--builds-dir`) |
@@ -171,22 +170,23 @@ that required paid sponsorship upon exceeding a free limit.
 
 ### `prepare` stage
 
-| Argument        | Default     | Description                                                                                                                                                     |
-|-----------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--concurrency` | 1           | Maximum number of concurrently running Tart VMs to calculate the `auto` resources                                                                               |
-| `--cpu`         | no override | Override default image CPU configuration (number of CPUs or `auto`<sup>1</sup>)                                                                                 |
-| `--memory`      | no override | Override default image memory configuration (size in megabytes or `auto`<sup>1</sup>)                                                                           |
-| `--dir`         |             | `--dir` arguments to pass to `tart run`, can be specified multiple times                                                                                        |
-| `--disk`        |             | `--disk` arguments to pass to `tart run`, can be specified multiple times                                                                                       |
-| `--auto-prune`  | true        | Whether to enable or disable the Tart's auto-pruning mechanism (sets the `TART_NO_AUTO_PRUNE` environment variable for Tart command invocations under the hood) |
-| `--allow-image` |             | only allow running images that match the given [doublestar](https://github.com/bmatcuk/doublestar)-compatible pattern, can be specified multiple times          |
+| Argument          | Default     | Description                                                                                                                                                     |
+| ----------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--concurrency`   | 1           | Maximum number of concurrently running Tart VMs to calculate the `auto` resources                                                                               |
+| `--cpu`           | no override | Override default image CPU configuration (number of CPUs or `auto`<sup>1</sup>)                                                                                 |
+| `--memory`        | no override | Override default image memory configuration (size in megabytes or `auto`<sup>1</sup>)                                                                           |
+| `--dir`           |             | `--dir` arguments to pass to `tart run`, can be specified multiple times                                                                                        |
+| `--disk`          |             | `--disk` arguments to pass to `tart run`, can be specified multiple times                                                                                       |
+| `--auto-prune`    | true        | Whether to enable or disable the Tart's auto-pruning mechanism (sets the `TART_NO_AUTO_PRUNE` environment variable for Tart command invocations under the hood) |
+| `--allow-image`   |             | only allow running images that match the given [doublestar](https://github.com/bmatcuk/doublestar)-compatible pattern, can be specified multiple times          |
+| `--default-image` |             | A fallback tart image to use, in case the job does not specify one                                                                                              |
 
 <sup>1</sup>: automatically distributes all host resources according to the concurrency level (for example, VM gets all of the host CPU and RAM assigned when `--concurrency` is 1, and half of that when `--concurrency` is 2)
 
 ## Supported environment variables
 
 | Name                                  | Default        | Description                                                                                                                                                                                                                                                                                                                                                                                                                              |
-|---------------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `TART_EXECUTOR_ALWAYS_PULL`           | true           | Always pull the latest version of the Tart image (`true`) or only when the image doesn't exist locally (`false`)                                                                                                                                                                                                                                                                                                                         |
 | `TART_EXECUTOR_BRIDGED`               |                | Use bridged networking, for example, "en0". Use `tart run --net-bridged=list` to see names of all available interfaces.                                                                                                                                                                                                                                                                                                                  |
 | `TART_EXECUTOR_HEADLESS`              | true           | Run the VM in headless mode (`true`) or with GUI (`false`)                                                                                                                                                                                                                                                                                                                                                                               |

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -102,7 +102,7 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 		}
 
 		gitLabEnv.JobImage = defaultImage
-		log.Println("No image provided, falling back to default: %s", defaultImage)
+		log.Printf("No image provided, falling back to default: %s\n", defaultImage)
 	}
 
 	if err := ensureImageIsAllowed(gitLabEnv.JobImage); err != nil {

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -95,7 +95,12 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if gitLabEnv.JobImage == "" && defaultImage != "" {
+	if gitLabEnv.JobImage == "" {
+		if defaultImage == "" {
+			fmt.Errorf("%w: CUSTOM_ENV_CI_JOB_ID is missing and no default image was provided", ErrFailed)
+			return nil
+		}
+
 		gitLabEnv.JobImage = defaultImage
 		log.Println("No image provided, falling back to default: %s", defaultImage)
 	}

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -39,6 +39,7 @@ var customDirectoryMounts []string
 var customDiskMounts []string
 var autoPrune bool
 var allowedImagePatterns []string
+var defaultImage string
 
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
@@ -63,6 +64,8 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().StringArrayVar(&allowedImagePatterns, "allow-image", []string{},
 		"only allow running images that match the given doublestar-compatible pattern, "+
 			"can be specified multiple times (e.g. --allow-image \"ghcr.io/cirruslabs/macos-sonoma-*\")")
+	command.PersistentFlags().StringVar(&defaultImage, "default-image", "",
+		"A fallback tart image to use, in case the job does not specify one")
 
 	return command
 }
@@ -90,6 +93,11 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 	gitLabEnv, err := gitlab.InitEnv()
 	if err != nil {
 		return err
+	}
+
+	if gitLabEnv.JobImage == "" && defaultImage != "" {
+		gitLabEnv.JobImage = defaultImage
+		log.Println("No image provided, falling back to default: %s", defaultImage)
 	}
 
 	if err := ensureImageIsAllowed(gitLabEnv.JobImage); err != nil {

--- a/internal/gitlab/env.go
+++ b/internal/gitlab/env.go
@@ -41,10 +41,7 @@ func InitEnv() (*Env, error) {
 	result.JobID = jobID
 	jobImage, ok := os.LookupEnv("CUSTOM_ENV_CI_JOB_IMAGE")
 	if !ok {
-		jobImage, ok = os.LookupEnv("CUSTOM_ENV_CI_DEFAULT_JOB_IMAGE")
-		if !ok {
-			return nil, fmt.Errorf("%w: CUSTOM_ENV_CI_JOB_IMAGE and CUSTOM_ENV_CI_DEFAULT_JOB_IMAGE are missing", ErrGitLabEnv)
-		}
+		return nil, fmt.Errorf("%w: CUSTOM_ENV_CI_JOB_IMAGE is missing", ErrGitLabEnv)
 	}
 
 	result.JobImage = jobImage

--- a/internal/gitlab/env.go
+++ b/internal/gitlab/env.go
@@ -41,7 +41,7 @@ func InitEnv() (*Env, error) {
 	result.JobID = jobID
 	jobImage, ok := os.LookupEnv("CUSTOM_ENV_CI_JOB_IMAGE")
 	if !ok {
-		return nil, fmt.Errorf("%w: CUSTOM_ENV_CI_JOB_IMAGE is missing", ErrGitLabEnv)
+		fmt.Sprintf("%w: CUSTOM_ENV_CI_JOB_IMAGE is missing", ErrGitLabEnv)
 	}
 
 	result.JobImage = jobImage

--- a/internal/gitlab/env.go
+++ b/internal/gitlab/env.go
@@ -41,7 +41,10 @@ func InitEnv() (*Env, error) {
 	result.JobID = jobID
 	jobImage, ok := os.LookupEnv("CUSTOM_ENV_CI_JOB_IMAGE")
 	if !ok {
-		return nil, fmt.Errorf("%w: CUSTOM_ENV_CI_JOB_IMAGE is missing", ErrGitLabEnv)
+		jobImage, ok = os.LookupEnv("CUSTOM_ENV_CI_DEFAULT_JOB_IMAGE")
+		if !ok {
+			return nil, fmt.Errorf("%w: CUSTOM_ENV_CI_JOB_IMAGE and CUSTOM_ENV_CI_DEFAULT_JOB_IMAGE are missing", ErrGitLabEnv)
+		}
 	}
 
 	result.JobImage = jobImage


### PR DESCRIPTION
This PR introduces a new argument `default-image` for the prepare stage, replicating the functionality of the docker executor: if no `image` is provided by the job definition or via `CI_JOB_IMAGE`, fall back to a default image to use.

