### PR TITLE
move EnvPrefixGitLabRunner constant to gitlab namespace

### DIFF
--- a/internal/commands/cleanup/cleanup.go
+++ b/internal/commands/cleanup/cleanup.go
@@ -36,7 +36,7 @@ func cleanupVM(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tartConfig, err := tart.NewConfigFromEnvironment()
+	tartConfig, err := tart.NewConfigFromEnvironment(gitlab.EnvPrefixGitLabRunner)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -77,7 +77,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		JobEnv:    map[string]string{},
 	}
 
-	tartConfig, err := tart.NewConfigFromEnvironment()
+	tartConfig, err := tart.NewConfigFromEnvironment(gitlab.EnvPrefixGitLabRunner)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/run/run.go
+++ b/internal/commands/run/run.go
@@ -34,7 +34,7 @@ func runScriptInsideVM(cmd *cobra.Command, args []string) error {
 	// Monitor "tart run" command's output so it's not silenced
 	go vm.MonitorTartRunOutput()
 
-	config, err := tart.NewConfigFromEnvironment()
+	config, err := tart.NewConfigFromEnvironment(gitlab.EnvPrefixGitLabRunner)
 	if err != nil {
 		return err
 	}

--- a/internal/gitlab/env.go
+++ b/internal/gitlab/env.go
@@ -8,6 +8,15 @@ import (
 	"strconv"
 )
 
+const (
+	// EnvPrefixGitLabRunner is the environment variable prefix
+	// GitLab CI/CD adds [1] to prevent conflicts with system
+	// environment variables.
+	//
+	// [1]: https://docs.gitlab.com/runner/executors/custom.html#stages
+	EnvPrefixGitLabRunner = "CUSTOM_ENV_"
+)
+
 var ErrGitLabEnv = errors.New("GitLab environment error")
 
 type Env struct {
@@ -64,4 +73,10 @@ func InitEnv() (*Env, error) {
 	}
 
 	return result, nil
+}
+
+// LookupEnv passes the given key prefixed with
+// [EnvPrefixGitLabRunner] to [os.LookupEnv].
+func LookupEnv(key string) (string, bool) {
+	return os.LookupEnv(EnvPrefixGitLabRunner + key)
 }

--- a/internal/tart/config.go
+++ b/internal/tart/config.go
@@ -9,35 +9,41 @@ import (
 var ErrConfigFromEnvironmentFailed = errors.New("failed to load config from environment")
 
 const (
-	// GitLab CI/CD environment adds "CUSTOM_ENV_" prefix[1] to prevent
-	// conflicts with system environment variables.
-	//
-	// [1]: https://docs.gitlab.com/runner/executors/custom.html#stages
-	envPrefixGitLabRunner = "CUSTOM_ENV_"
-
 	// The prefix that we use to avoid confusion with Cirrus CI Cloud variables
 	// and remove repetition from the Config's struct declaration.
-	envPrefixTartExecutor = "TART_EXECUTOR_"
+	EnvPrefixTartExecutor = "TART_EXECUTOR_"
 
 	// EnvTartExecutorInternalBuildsDir is an internal environment variable
 	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
 	// by the user.
-	EnvTartExecutorInternalBuildsDir = "TART_EXECUTOR_INTERNAL_BUILDS_DIR"
+	EnvTartExecutorInternalBuildsDir = EnvPrefixTartExecutor + "INTERNAL_BUILDS_DIR"
 
 	// EnvTartExecutorInternalBuildsDirOnHost is an internal environment variable
 	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
 	// by the user.
-	EnvTartExecutorInternalBuildsDirOnHost = "TART_EXECUTOR_INTERNAL_BUILDS_DIR_ON_HOST"
+	EnvTartExecutorInternalBuildsDirOnHost = EnvPrefixTartExecutor + "INTERNAL_BUILDS_DIR_ON_HOST"
 
 	// EnvTartExecutorInternalCacheDir is an internal environment variable
 	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
 	// by the user.
-	EnvTartExecutorInternalCacheDir = "TART_EXECUTOR_INTERNAL_CACHE_DIR"
+	EnvTartExecutorInternalCacheDir = EnvPrefixTartExecutor + "INTERNAL_CACHE_DIR"
 
 	// EnvTartExecutorInternalCacheDirOnHost is an internal environment variable
 	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
 	// by the user.
-	EnvTartExecutorInternalCacheDirOnHost = "TART_EXECUTOR_INTERNAL_CACHE_DIR_ON_HOST"
+	EnvTartExecutorInternalCacheDirOnHost = EnvPrefixTartExecutor + "INTERNAL_CACHE_DIR_ON_HOST"
+
+	// EnvTartRegistry is the environment variable containing the authentication
+	// principal for the image registry.
+	EnvTartRegistryUsername = "TART_REGISTRY_USERNAME"
+
+	// EnvTartRegistry is the environment variable containing the authentication
+	// secret for the image registry.
+	EnvTartRegistryPassword = "TART_REGISTRY_PASSWORD" //nolint: gosec
+
+	// EnvTartRegistry is the environment variable containing the address
+	// of the image registry.
+	EnvTartRegistryHostname = "TART_REGISTRY_HOSTNAME"
 )
 
 type Config struct {
@@ -59,11 +65,11 @@ type Config struct {
 	Timezone            string `env:"TIMEZONE"`
 }
 
-func NewConfigFromEnvironment() (Config, error) {
+func NewConfigFromEnvironment(prefix string) (Config, error) {
 	var config Config
 
 	if err := env.ParseWithOptions(&config, env.Options{
-		Prefix: envPrefixGitLabRunner + envPrefixTartExecutor,
+		Prefix: prefix + EnvPrefixTartExecutor,
 	}); err != nil {
 		return config, fmt.Errorf("%w: %v", ErrConfigFromEnvironmentFailed, err)
 	}


### PR DESCRIPTION
both gitlab.EnvPrefixGitLabRunner and tart.EnvPrefixTartExecutor are public now for consistency sake. initializing the tart configuration requires passing a key prefix, which is usually gitlab.EnvPrefixGitLabRunner. providing the prefix ensures the gitlab and tart namespace remain independent.

additionally a proxy method for os.LookupEnv has been implemented utilizing the newly added constant as prefix for variable lookups.

this change is in preparation for #113