### PR TITLE
Expose GitLab job environment variables to Runner installation script

### DIFF
--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -204,6 +204,10 @@ func runPrepareVM(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		if err := stdinBuf.Close(); err != nil {
+			return err
+		}
+
 		if err := session.Wait(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Resolves https://github.com/cirruslabs/gitlab-tart-executor/issues/111.

Closes #113, closes #114, closes #115.