### PR TITLE
Emit SYSTEM_FAILURE_EXIT_CODE from non-run stages

### DIFF
--- a/internal/commands/cleanup/cleanup.go
+++ b/internal/commands/cleanup/cleanup.go
@@ -12,13 +12,19 @@ func NewCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "cleanup",
 		Short: "Cleanup Tart VM after job finishes",
-		RunE:  cleanupVM,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cleanupVM(cmd, args); err != nil {
+				return gitlab.NewSystemFailureError(err)
+			}
+
+			return nil
+		},
 	}
 
 	return command
 }
 
-func cleanupVM(cmd *cobra.Command, args []string) error {
+func cleanupVM(_ *cobra.Command, _ []string) error {
 	gitLabEnv, err := gitlab.InitEnv()
 	if err != nil {
 		return err

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -30,7 +30,13 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Configure GitLab Runner",
-		RunE:  runConfig,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runConfig(cmd, args); err != nil {
+				return gitlab.NewSystemFailureError(err)
+			}
+
+			return nil
+		},
 	}
 
 	cmd.PersistentFlags().StringVar(&buildsDir, "builds-dir", "",
@@ -49,7 +55,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func runConfig(cmd *cobra.Command, args []string) error {
+func runConfig(_ *cobra.Command, _ []string) error {
 	gitlabRunnerDriver := map[string]string{
 		driverName:    tart.TartCommandName,
 		driverVersion: version.FullVersion,

--- a/internal/commands/prepare/prepare.go
+++ b/internal/commands/prepare/prepare.go
@@ -46,7 +46,13 @@ func NewCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "prepare",
 		Short: "Prepare a Tart VM for execution",
-		RunE:  runPrepareVM,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runPrepareVM(cmd, args); err != nil {
+				return gitlab.NewSystemFailureError(err)
+			}
+
+			return nil
+		},
 	}
 
 	command.PersistentFlags().Uint64Var(&concurrency, "concurrency", 1,
@@ -74,7 +80,7 @@ func NewCommand() *cobra.Command {
 }
 
 //nolint:gocognit,gocyclo,nestif // looks good for now
-func runPrepareVM(cmd *cobra.Command, args []string) error {
+func runPrepareVM(cmd *cobra.Command, _ []string) error {
 	cpuOverride, err := parseCPUOverride(cmd.Context(), cpuOverrideRaw)
 	if err != nil {
 		return err

--- a/internal/gitlab/error.go
+++ b/internal/gitlab/error.go
@@ -1,0 +1,19 @@
+package gitlab
+
+type SystemFailureError struct {
+	inner error
+}
+
+func NewSystemFailureError(err error) error {
+	return &SystemFailureError{
+		inner: err,
+	}
+}
+
+func (outer *SystemFailureError) Error() string {
+	return outer.inner.Error()
+}
+
+func (outer *SystemFailureError) Unwrap() error {
+	return outer.inner
+}


### PR DESCRIPTION
This way it's possible to `retry` on `runner_system_failure` specifically, and as a bonus, GitLab automatically re-tries the job for up to 3 times by default when the error does not come from the `run` stage (e.g. from `prepare` stage):

![Screenshot 2025-05-12 at 16 45 23](https://github.com/user-attachments/assets/398c8371-e1f4-407f-90fe-a1c40e01f5f3)
