### PR TITLE
README.md: Set clean_git_config = false in sample config.toml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ concurrent = 2
 [[runners]]
   # ...
   executor = "custom"
+  clean_git_config = false
   [runners.feature_flags]
     FF_RESOLVE_FULL_TLS_CHAIN = false
   [runners.custom]
@@ -110,6 +111,7 @@ concurrent = 2
 [[runners]]
   # ...
   executor = "custom"
+  clean_git_config = false
   [runners.feature_flags]
     FF_RESOLVE_FULL_TLS_CHAIN = false
   [runners.custom]


### PR DESCRIPTION
By default, the GitLab runner "cleans" the git config before reusing an existing repo. This results in settings like core.ignorecase and core.precomposeunicode being removed; these are set automatically true for new repos on macOS, and disabling them can cause weird errors.

clean_git_config defaults to true when using the custom executor but is false when using the shell executor, this is why typical macOS CI setups using the shell executor don't need this option.