### PR TITLE
Pass vm name via variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ test:
     TART_EXECUTOR_SSH_PASSWORD: "custom-password"
 ```
 
+### Exposing VM name
+
+Each ephemeral VM gets a unique name derived from the GitLab job ID (e.g. `gitlab-123`). You can expose this name as an environment variable inside the job by setting `TART_EXECUTOR_PASS_VM_NAME`.
+
+**One-time guest image setup** — add the following line to `/etc/ssh/sshd_config` in your VM template image:
+
+```shell
+AcceptEnv TART_EXECUTOR_VM_NAME
+```
+
 ## Licensing
 
 Tart Executor is open sourced under MIT license so people can base their own executors in Go of this code.
@@ -248,6 +258,7 @@ that required paid sponsorship upon exceeding a free limit.
 | `TART_EXECUTOR_SSH_PASSWORD`          | admin          | SSH password to use when connecting to the VM                                                                                                                                                                                                                                                                                                                                                                                            |
 | `TART_EXECUTOR_SSH_PORT`              | 22             | Connect to the VM at the given SSH port                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `TART_EXECUTOR_SSH_USERNAME`          | admin          | SSH username to use when connecting to the VM                                                                                                                                                                                                                                                                                                                                                                                            |
+| `TART_EXECUTOR_PASS_VM_NAME`          | false          | Expose the VM name inside the guest job as `TART_EXECUTOR_VM_NAME` (`CI_JOB_ID`-based, e.g. `gitlab-123`) so pipeline scripts can use it as needed. Requires `AcceptEnv TART_EXECUTOR_VM_NAME` in the guest's `/etc/ssh/sshd_config` (see [VM name in job scripts](#exposing-vm-name-in-job-scripts)) |
 | `TART_EXECUTOR_TIMEZONE`              |                | Timezone to set in the guest (or `auto` to pick up the timezone from host), see `systemsetup listtimezones` for a list of possible timezones                                                                                                                                                                                                                                                                                             |
 | `TART_EXECUTOR_DISPLAY`               |                | Set VM display resolution to `<width>x<height>` (e.g. `1920x1080`)                                                                                                                                                                                                                                                                                                                                                                                          |
 

--- a/internal/commands/run/run.go
+++ b/internal/commands/run/run.go
@@ -64,6 +64,12 @@ func runScriptInsideVM(cmd *cobra.Command, args []string) error {
 	}
 	defer sshSession.Close()
 
+	if config.PassVMName {
+		if err := sshSession.Setenv("TART_EXECUTOR_VM_NAME", gitLabEnv.VirtualMachineID()); err != nil {
+			return err
+		}
+	}
+
 	// GitLab script ends with an `exit` command which will terminate the SSH session
 	sshSession.Stdin = scriptFile
 	sshSession.Stdout = os.Stdout

--- a/internal/gitlab/env.go
+++ b/internal/gitlab/env.go
@@ -20,7 +20,7 @@ type Env struct {
 type Registry struct {
 	Address  string
 	User     string
-	Password string //nolint:gosec // G117 is a false-positive here: we don't serialize this structure (e.g. JSON)
+	Password string  // G117 is a false-positive here: we don't serialize this structure (e.g. JSON)
 }
 
 func (e Env) VirtualMachineID() string {

--- a/internal/tart/config.go
+++ b/internal/tart/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	HostDir             bool   `env:"HOST_DIR"`
 	Shell               string `env:"SHELL"`
 	InstallGitlabRunner string `env:"INSTALL_GITLAB_RUNNER"`
+	PassVMName          bool   `env:"PASS_VM_NAME" envDefault:"false"`
 	Timezone            string `env:"TIMEZONE"`
 	Display             string `env:"DISPLAY"`
 }


### PR DESCRIPTION
This simple change sets the VM Hostname to the configured gitlab-id. Same as vm-name in on the tart runner e.g. `gitlab-123456`

I am using tart to execute test-pipelines and this will keep logging information about the used host and matched to the job id. to keep the original behavior, this feature is disabled by default and can be enabled via variable.

I already tested this local and my tart-runners and it worked fine.