### PR TITLE
commands/config: support `--default-ssh-password` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ concurrent = 2
 
 Tart Executor uses the default `admin:admin` credentials when connecting to the VM over SSH.
 
-If your image uses different credentials, set `TART_EXECUTOR_SSH_USERNAME` and/or `TART_EXECUTOR_SSH_PASSWORD` variables either in GitLab UI or in `.gitlab-ci.yml`:
+If your image uses different credentials, you have two options:
+
+#### Option 1: CI/CD variable
+
+Set `TART_EXECUTOR_SSH_USERNAME` and/or `TART_EXECUTOR_SSH_PASSWORD` in GitLab UI or in `.gitlab-ci.yml`:
 
 ```yaml
 test:
@@ -185,6 +189,28 @@ test:
     TART_EXECUTOR_SSH_PASSWORD: "custom-password"
 ```
 
+#### Option 2: Runner's `config.toml`
+
+Pass the SSH password via the `config` stage's `--default-ssh-password` flag in the runner's `config.toml`:
+
+```toml
+[[runners]]
+  executor = "custom"
+  [runners.custom]
+    config_exec = "gitlab-tart-executor"
+    config_args = ["config", "--default-ssh-password", "custom-password"]
+    prepare_exec = "gitlab-tart-executor"
+    prepare_args = ["prepare"]
+    run_exec = "gitlab-tart-executor"
+    run_args = ["run"]
+    cleanup_exec = "gitlab-tart-executor"
+    cleanup_args = ["cleanup"]
+```
+
+This keeps the default password out of CI/CD variables, preventing it from leaking into the job environment.
+
+**Precedence:** When both `TART_EXECUTOR_SSH_PASSWORD` (CI/CD variable) and `--default-ssh-password` are set, the CI/CD variable takes precedence. If neither is set, the built-in default (`admin`) is used.
+
 ## Licensing
 
 Tart Executor is open sourced under MIT license so people can base their own executors in Go of this code.
@@ -199,6 +225,7 @@ that required paid sponsorship upon exceeding a free limit.
 |----------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--builds-dir`                   |         | Path to a directory on host to use for storing builds, automatically mounts that directory to the guest VM (mutually exclusive with `--guest-builds-dir`)                                             |
 | `--cache-dir`                    |         | Path to a directory on host to use for caching purposes, automatically mounts that directory to the guest VM (mutually exclusive with `--guest-cache-dir`)                                            |
+| `--default-ssh-password`         |         | SSH password to use when connecting to the VM when the job does not specify `TART_EXECUTOR_SSH_PASSWORD` (prevents the password from leaking into the job environment)                                |
 | `--guest-builds-dir`<sup>1</sup> |         | Path to a directory in guest to use for storing builds, useful when mounting a block device (via [`--disk` command-line argument](#prepare-stage)) to the VM (mutually exclusive with `--builds-dir`) |
 | `--guest-cache-dir`<sup>1</sup>  |         | Path to a directory in guest to use for caching purposes, useful when mounting a block device (via [`--disk` command-line argument](#prepare-stage) to the VM (mutually exclusive with `--cache-dir`) |
 

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -19,8 +19,9 @@ const (
 var ErrConfigFailed = errors.New("configuration stage failed")
 
 var (
-	buildsDir string
-	cacheDir  string
+	buildsDir           string
+	cacheDir            string
+	defaultSSHPassword  string
 
 	guestBuildsDir string
 	guestCacheDir  string
@@ -51,6 +52,9 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&guestCacheDir, "guest-cache-dir", "",
 		"path to a directory in guest to use for caching purposes, useful when mounting a block device "+
 			"via \"--disk\" command-line argument (mutually exclusive with \"--cache-dir\")")
+	cmd.PersistentFlags().StringVar(&defaultSSHPassword, "default-ssh-password", "",
+		"SSH password to use when connecting to the VM when the job does not specify "+
+			"TART_EXECUTOR_SSH_PASSWORD (prevents the password from leaking into the job environment)")
 
 	return cmd
 }
@@ -149,6 +153,12 @@ func runConfig(_ *cobra.Command, _ []string) error {
 	// because GitLab Runner won't do this for us
 	gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalBuildsDir] = gitlabRunnerConfig.BuildsDir
 	gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalCacheDir] = gitlabRunnerConfig.CacheDir
+
+	// Propagate the default SSH password from the runner's config.toml
+	// via the internal env var so it doesn't leak into the job environment
+	if defaultSSHPassword != "" {
+		gitlabRunnerConfig.JobEnv[tart.EnvTartExecutorInternalSSHPassword] = defaultSSHPassword
+	}
 
 	jsonBytes, err := json.MarshalIndent(&gitlabRunnerConfig, "", "  ")
 	if err != nil {

--- a/internal/tart/config.go
+++ b/internal/tart/config.go
@@ -3,6 +3,8 @@ package tart
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/caarlos0/env/v8"
 )
 
@@ -38,6 +40,11 @@ const (
 	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
 	// by the user.
 	EnvTartExecutorInternalCacheDirOnHost = "TART_EXECUTOR_INTERNAL_CACHE_DIR_ON_HOST"
+
+	// EnvTartExecutorInternalSSHPassword is an internal environment variable
+	// that does not use the "CUSTOM_ENV_" prefix, thus preventing the override
+	// by the user.
+	EnvTartExecutorInternalSSHPassword = "TART_EXECUTOR_INTERNAL_SSH_PASSWORD"
 )
 
 type Config struct {
@@ -67,6 +74,22 @@ func NewConfigFromEnvironment() (Config, error) {
 		Prefix: envPrefixGitLabRunner + envPrefixTartExecutor,
 	}); err != nil {
 		return config, fmt.Errorf("%w: %v", ErrConfigFromEnvironmentFailed, err)
+	}
+
+	// Three-tier precedence for the SSH password:
+	//
+	//   1. CI/CD variable (CUSTOM_ENV_TART_EXECUTOR_SSH_PASSWORD) — backward
+	//      compatible, but leaks into the job's environment.
+	//
+	//   2. Runner-side internal variable (TART_EXECUTOR_INTERNAL_SSH_PASSWORD)
+	//      set by the config stage's --default-ssh-password flag — doesn't leak.
+	//
+	//   3. Built-in default ("admin").
+	if _, ciCdSet := os.LookupEnv(envPrefixGitLabRunner + envPrefixTartExecutor + "SSH_PASSWORD"); ciCdSet {
+		// The env.ParseWithOptions call above already parsed the CI/CD variable,
+		// so config.SSHPassword is correct — nothing to do.
+	} else if internalPassword, ok := os.LookupEnv(EnvTartExecutorInternalSSHPassword); ok {
+		config.SSHPassword = internalPassword
 	}
 
 	return config, nil

--- a/internal/tart/config_test.go
+++ b/internal/tart/config_test.go
@@ -1,0 +1,78 @@
+package tart_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cirruslabs/gitlab-tart-executor/internal/tart"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfigFromEnvironment_SSHPasswordPrecedence(t *testing.T) {
+	envPrefix := "CUSTOM_ENV_TART_EXECUTOR_"
+	envCI := envPrefix + "SSH_PASSWORD"
+	envInternal := "TART_EXECUTOR_INTERNAL_SSH_PASSWORD"
+
+	tests := []struct {
+		name     string
+		ciValue  string
+		intValue string
+		want     string
+	}{
+		{
+			name: "ci_variable_takes_precedence_over_internal",
+			ciValue: "from-ci",
+			intValue: "from-internal",
+			want: "from-ci",
+		},
+		{
+			name: "internal_used_when_ci_not_set",
+			ciValue: "",
+			intValue: "from-internal",
+			want: "from-internal",
+		},
+		{
+			name: "default_used_when_nothing_set",
+			ciValue: "",
+			intValue: "",
+			want: "admin",
+		},
+		{
+			name: "ci_variable_without_internal",
+			ciValue: "from-ci-only",
+			intValue: "",
+			want: "from-ci-only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			savedCI, hadCI := os.LookupEnv(envCI)
+			savedInternal, hadInternal := os.LookupEnv(envInternal)
+
+			os.Unsetenv(envCI)
+			os.Unsetenv(envInternal)
+			if tt.ciValue != "" {
+				os.Setenv(envCI, tt.ciValue)
+			}
+			if tt.intValue != "" {
+				os.Setenv(envInternal, tt.intValue)
+			}
+
+			defer func() {
+				os.Unsetenv(envCI)
+				os.Unsetenv(envInternal)
+				if hadCI {
+					os.Setenv(envCI, savedCI)
+				}
+				if hadInternal {
+					os.Setenv(envInternal, savedInternal)
+				}
+			}()
+
+			config, err := tart.NewConfigFromEnvironment()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, config.SSHPassword)
+		})
+	}
+}


### PR DESCRIPTION
This allows the runner to provide a default password without leaking it into the job environment.

Fixes: #144

---
Assisted-by: OpenCode with DeepSeek v4 Flash

I reviewed the code and approve of the logic (at least as far as my Golang knowledge suffices).